### PR TITLE
Fix: Add aria-label to link for accessibility

### DIFF
--- a/src/components/ScrollToTop/ScrollToTop.js
+++ b/src/components/ScrollToTop/ScrollToTop.js
@@ -15,7 +15,7 @@ const ScrollToTop = () => {
 
   return isVisible ? (
     <div className='scroll-top'>
-      <a href='#top'>
+      <a href='#top' aria-label='top'>
         <ArrowUpwardIcon fontSize='large' />
       </a>
     </div>


### PR DESCRIPTION
### Summary
This PR addresses an accessibility issue by adding an `aria-label` to the anchor tag containing the `ArrowUpwardIcon`. 

### Changes
- Added `aria-label="top"` to the anchor tag to ensure it is associated with a text label.

### Reason
The change resolves the `jsx-a11y/control-has-associated-label` linting error, improving accessibility for screen readers and users relying on assistive technologies.
<img width="836" alt="Screenshot 2024-07-11 at 11 51 44 AM" src="https://github.com/rjshkhr/cleanfolio/assets/54373597/e57068b8-f6a7-49c6-bda1-f82a4d67fb4b">

### Impact
This change enhances the accessibility of the application without altering its visual appearance or functionality.

### Testing
- Verified that the `jsx-a11y/control-has-associated-label` error is resolved.
- Confirmed that the link still functions as intended.
<img width="501" alt="image" src="https://github.com/rjshkhr/cleanfolio/assets/54373597/7687fa4b-b273-4c6d-b387-4028a775c6d5">
